### PR TITLE
Bugfixes and enhancements to format_taxa

### DIFF
--- a/R/taxa.R
+++ b/R/taxa.R
@@ -66,7 +66,8 @@ make_binomial_name <- function (genus_name, specific_name) {
 #' @return A character vector of formatted taxonomic assignments.
 #' @export
 format_taxa <- function(taxdf, guide = "Phylum", sep = " - ",
-                        unclassified_prefix = "unclassified") {
+                        unclassified_prefix = "unclassified",
+                        all_unclassified = "no assignment") {
   if (is.null(guide) || is.na(guide)) {
     guide_idx <- NULL
   } else if (is.integer(guide)) {
@@ -76,14 +77,16 @@ format_taxa <- function(taxdf, guide = "Phylum", sep = " - ",
   }
   apply(
     taxdf, 1, format_lineage_vector, guide_idx = guide_idx, sep = sep,
-    unclassified_prefix = unclassified_prefix)
+    unclassified_prefix = unclassified_prefix,
+    all_unclassified = all_unclassified)
 }
 
 format_lineage_vector <- function (x, guide_idx = 2, sep = " - ",
-                                 unclassified_prefix = "unclassified") {
+                                 unclassified_prefix = "unclassified",
+                                 all_unclassified = "no assignment") {
   primary_idx <- max_idx(x)
-  # Nothing is filled in, return NA
-  if (is.na(primary_idx)) return(NA_character_)
+  # Nothing is filled in, return all_unclassified
+  if (is.na(primary_idx)) return(all_unclassified)
   primary_taxon <- x[primary_idx]
   # Add a prefix if necessary
   if ((primary_idx < length(x)) & (!is.null(unclassified_prefix))) {

--- a/R/taxa.R
+++ b/R/taxa.R
@@ -79,7 +79,7 @@ format_taxa <- function(taxdf, guide = "Phylum", sep = " - ",
     unclassified_prefix = unclassified_prefix)
 }
 
-format_lineage_vector <- function (x, guide_idx, sep = " - ",
+format_lineage_vector <- function (x, guide_idx = 2, sep = " - ",
                                  unclassified_prefix = "unclassified") {
   primary_idx <- max_idx(x)
   # Nothing is filled in, return NA

--- a/R/taxa.R
+++ b/R/taxa.R
@@ -82,19 +82,15 @@ format_taxa <- function(taxdf, guide = "Phylum", sep = " - ",
 }
 
 format_lineage_vector <- function (x, guide_idx = 2, sep = " - ",
-                                 unclassified_prefix = "unclassified",
-                                 all_unclassified = "no assignment") {
+                                   unclassified_prefix = "unclassified",
+                                   all_unclassified = "no assignment") {
   primary_idx <- max_idx(x)
-  # Nothing is filled in, return all_unclassified
   if (is.na(primary_idx)) return(all_unclassified)
   primary_taxon <- x[primary_idx]
-  # Add a prefix if necessary
   if ((primary_idx < length(x)) & (!is.null(unclassified_prefix))) {
     primary_taxon <- paste(unclassified_prefix, primary_taxon)
   }
-  # No guide, return the lowest-ranking taxon
   if (is.null(guide_idx)) return(primary_taxon)
-  # Nothing is filled in below the guide, return the lowest-ranking taxon
   if (primary_idx <= guide_idx) return(primary_taxon)
   guide_taxon <- x[guide_idx]
   paste(guide_taxon, primary_taxon, sep = sep)

--- a/R/taxa.R
+++ b/R/taxa.R
@@ -78,14 +78,25 @@ format_taxa <- function(taxdf, guide = "Phylum", sep = " - ",
 
 format_lineage_vector <- function (x, guide_idx, sep = " - ",
                                  unclassified_prefix = "unclassified") {
-  primary_idx <- max(which(!is.na(x)))
-  if (primary_idx < guide_idx) return(paste(x, collapse = sep))
-  guide_taxon <- x[guide_idx]
-  if (primary_idx == guide_idx) return(guide_taxon)
+  primary_idx <- max_idx(x)
+  # Nothing is filled in, return NA
+  if (is.na(primary_idx)) return(NA_character_)
   primary_taxon <- x[primary_idx]
+  # Nothing is filled in below the guide, return the lowest-ranking taxon
+  if (primary_idx <= guide_idx) return(primary_taxon)
+  guide_taxon <- x[guide_idx]
+  # Add a prefix if necessary
   if ((primary_idx < length(x)) & (!is.null(unclassified_prefix))) {
-    prefixed <- paste(unclassified_prefix, primary_taxon)
-    return(paste(guide_taxon, prefixed, sep = sep))
+    primary_taxon <- paste(unclassified_prefix, primary_taxon)
   }
-  return(paste(guide_taxon, primary_taxon, sep = sep))
+  paste(guide_taxon, primary_taxon, sep = sep)
+}
+
+max_idx <- function (x) {
+  is_filled <- !is.na(x)
+  if (any(is_filled)) {
+    max(which(is_filled))
+  } else {
+    NA_integer_
+  }
 }

--- a/R/taxa.R
+++ b/R/taxa.R
@@ -71,22 +71,21 @@ format_taxa <- function(taxdf, guide = "Phylum", sep = " - ",
   } else {
     guide_idx <- match(guide, colnames(taxdf))
   }
-  apply(taxdf, 1, function (x) {
-    n_total <- length(x)
-    n_filled <- filled_length(x)
-    if (n_filled < guide_idx) return(paste(x, collapse = sep))
-    guide_taxon <- x[guide_idx]
-    if (n_filled == guide_idx) return(guide_taxon)
-    lowest_taxon <- x[n_filled]
-    if ((n_filled < n_total) & (!is.null(unclassified_prefix))) {
-      prefixed <- paste(unclassified_prefix, lowest_taxon)
-      return(paste(guide_taxon, prefixed, sep = sep))
-    }
-    return(paste(guide_taxon, lowest_taxon, sep = sep))
-  })
+  apply(
+    taxdf, 1, format_lineage_vector, guide_idx = guide_idx, sep = sep,
+    unclassified_prefix = unclassified_prefix)
 }
 
-filled_length <- function (x) {
-  n_empty <- match(TRUE, cumsum(is.na(rev(x))) > 0, nomatch = 0)
-  length(x) - n_empty
+format_lineage_vector <- function (x, guide_idx, sep = " - ",
+                                 unclassified_prefix = "unclassified") {
+  primary_idx <- max(which(!is.na(x)))
+  if (primary_idx < guide_idx) return(paste(x, collapse = sep))
+  guide_taxon <- x[guide_idx]
+  if (primary_idx == guide_idx) return(guide_taxon)
+  primary_taxon <- x[primary_idx]
+  if ((primary_idx < length(x)) & (!is.null(unclassified_prefix))) {
+    prefixed <- paste(unclassified_prefix, primary_taxon)
+    return(paste(guide_taxon, prefixed, sep = sep))
+  }
+  return(paste(guide_taxon, primary_taxon, sep = sep))
 }

--- a/R/taxa.R
+++ b/R/taxa.R
@@ -63,6 +63,8 @@ make_binomial_name <- function (genus_name, specific_name) {
 #'   will use the lowest-ranking taxon available. In this case, a prefix will
 #'   be added indicate that the lowest-ranking taxon was undetermined. If
 #'   unclassified_prefix is `NULL`, no prefix will be added.
+#' @param all_unclassified If all the taxa are `NA`, this value will be used in
+#'   the result.
 #' @return A character vector of formatted taxonomic assignments.
 #' @export
 format_taxa <- function(taxdf, guide = "Phylum", sep = " - ",

--- a/R/taxa.R
+++ b/R/taxa.R
@@ -55,8 +55,9 @@ make_binomial_name <- function (genus_name, specific_name) {
 #' Format taxonomic assignments for presentation
 #'
 #' @param taxdf A data frame containing taxonomic assignments.
-#' @param guide Column name of high-ranking taxa to use as a guide
-#'   for lower-ranking taxa.
+#' @param guide Column name or column number of high-ranking taxa to use as a
+#'   guide for lower-ranking taxa. If guide is `NULL`, no guide taxon will be
+#'   used.
 #' @param sep Separator to use between guide taxon and lowest-ranking taxon.
 #' @param unclassified_prefix If the lowest-ranking taxon is `NA`, the function
 #'   will use the lowest-ranking taxon available. In this case, a prefix will
@@ -66,7 +67,9 @@ make_binomial_name <- function (genus_name, specific_name) {
 #' @export
 format_taxa <- function(taxdf, guide = "Phylum", sep = " - ",
                         unclassified_prefix = "unclassified") {
-  if (is.integer(guide)) {
+  if (is.null(guide) || is.na(guide)) {
+    guide_idx <- NULL
+  } else if (is.integer(guide)) {
     guide_idx <- guide
   } else {
     guide_idx <- match(guide, colnames(taxdf))
@@ -82,13 +85,15 @@ format_lineage_vector <- function (x, guide_idx, sep = " - ",
   # Nothing is filled in, return NA
   if (is.na(primary_idx)) return(NA_character_)
   primary_taxon <- x[primary_idx]
-  # Nothing is filled in below the guide, return the lowest-ranking taxon
-  if (primary_idx <= guide_idx) return(primary_taxon)
-  guide_taxon <- x[guide_idx]
   # Add a prefix if necessary
   if ((primary_idx < length(x)) & (!is.null(unclassified_prefix))) {
     primary_taxon <- paste(unclassified_prefix, primary_taxon)
   }
+  # No guide, return the lowest-ranking taxon
+  if (is.null(guide_idx)) return(primary_taxon)
+  # Nothing is filled in below the guide, return the lowest-ranking taxon
+  if (primary_idx <= guide_idx) return(primary_taxon)
+  guide_taxon <- x[guide_idx]
   paste(guide_taxon, primary_taxon, sep = sep)
 }
 

--- a/man/format_taxa.Rd
+++ b/man/format_taxa.Rd
@@ -8,14 +8,16 @@ format_taxa(
   taxdf,
   guide = "Phylum",
   sep = " - ",
-  unclassified_prefix = "unclassified"
+  unclassified_prefix = "unclassified",
+  all_unclassified = "no assignment"
 )
 }
 \arguments{
 \item{taxdf}{A data frame containing taxonomic assignments.}
 
-\item{guide}{Column name of high-ranking taxa to use as a guide
-for lower-ranking taxa.}
+\item{guide}{Column name or column number of high-ranking taxa to use as a
+guide for lower-ranking taxa. If guide is \code{NULL}, no guide taxon will be
+used.}
 
 \item{sep}{Separator to use between guide taxon and lowest-ranking taxon.}
 
@@ -23,6 +25,9 @@ for lower-ranking taxa.}
 will use the lowest-ranking taxon available. In this case, a prefix will
 be added indicate that the lowest-ranking taxon was undetermined. If
 unclassified_prefix is \code{NULL}, no prefix will be added.}
+
+\item{all_unclassified}{If all the taxa are \code{NA}, this value will be used in
+the result.}
 }
 \value{
 A character vector of formatted taxonomic assignments.

--- a/tests/testthat/test-taxa.R
+++ b/tests/testthat/test-taxa.R
@@ -1,26 +1,30 @@
 lineages <- c(
   "k__Bacteria; p__Firmicutes; c__Bacilli; o__Lactobacillales; f__Enterococcaceae; g__Enterococcus",
-  "k__Bacteria; p__Actinobacteria; c__Actinobacteria; o__Bifidobacteriales; f__Bifidobacteriaceae")
+  "k__Bacteria; p__Actinobacteria; c__Actinobacteria; o__Bifidobacteriales; f__Bifidobacteriaceae",
+  "k__Bacteria; p__Firmicutes; c__Clostridia; o__Clostridiales")
 
 taxa <- tibble::tibble(
-  Kingdom = c("k__Bacteria", "k__Bacteria"),
-  Phylum = c("p__Firmicutes", "p__Actinobacteria"),
-  Class = c("c__Bacilli", "c__Actinobacteria"),
-  Order = c("o__Lactobacillales", "o__Bifidobacteriales"),
-  Family = c("f__Enterococcaceae", "f__Bifidobacteriaceae"),
-  Genus = c("g__Enterococcus", NA_character_),
-  Species = c(NA_character_, NA_character_))
+  Kingdom = c("k__Bacteria", "k__Bacteria", "k__Bacteria"),
+  Phylum = c("p__Firmicutes", "p__Actinobacteria", "p__Firmicutes"),
+  Class = c("c__Bacilli", "c__Actinobacteria", "c__Clostridia"),
+  Order = c("o__Lactobacillales", "o__Bifidobacteriales", "o__Clostridiales"),
+  Family = c("f__Enterococcaceae", "f__Bifidobacteriaceae", NA_character_),
+  Genus = c("g__Enterococcus", NA_character_, NA_character_),
+  Species = c(NA_character_, NA_character_, NA_character_))
 
 assignments <- c(
   "p__Firmicutes - g__Enterococcus",
-  "p__Actinobacteria - unclassified f__Bifidobacteriaceae")
+  "p__Actinobacteria - unclassified f__Bifidobacteriaceae",
+  "p__Firmicutes - unclassified o__Clostridiales")
 
 test_that("split_lineage works", {
   expect_equal(split_lineage(lineages), taxa)
 })
 
 test_that("remove_rank_prefix works for individual taxa", {
-  expect_equal(remove_rank_prefix(taxa$Class), c("Bacilli", "Actinobacteria"))
+  expect_equal(
+    remove_rank_prefix(taxa$Class),
+    c("Bacilli", "Actinobacteria", "Clostridia"))
 })
 
 test_that("remove_rank_prefix does not leave empty strings", {
@@ -30,7 +34,8 @@ test_that("remove_rank_prefix does not leave empty strings", {
 test_that("remove_rank_prefix works for lineages", {
   expect_equal(remove_rank_prefix(lineages), c(
       "Bacteria; Firmicutes; Bacilli; Lactobacillales; Enterococcaceae; Enterococcus",
-      "Bacteria; Actinobacteria; Actinobacteria; Bifidobacteriales; Bifidobacteriaceae"))
+      "Bacteria; Actinobacteria; Actinobacteria; Bifidobacteriales; Bifidobacteriaceae",
+      "Bacteria; Firmicutes; Clostridia; Clostridiales"))
 })
 
 test_that("simplify_assignments works", {

--- a/tests/testthat/test-taxa.R
+++ b/tests/testthat/test-taxa.R
@@ -47,3 +47,15 @@ test_that("make_binomial_name works", {
     make_binomial_name(c("[Ruminococcus]", "Bacteroides"), c("gnavus", NA)),
     c("[Ruminococcus] gnavus", NA))
 })
+
+test_that("format_lineage_vector works", {
+  expect_equal(
+    format_lineage_vector(c("a", "b", "c", "d"), 2),
+    "b - d")
+  expect_equal(format_lineage_vector(
+    c("a", "b", "c", "d", NA), 2),
+    "b - unclassified d")
+  expect_equal(format_lineage_vector(
+    c("a", "b", "c", "d", NA, NA), 2),
+    "b - unclassified d")
+})

--- a/tests/testthat/test-taxa.R
+++ b/tests/testthat/test-taxa.R
@@ -48,14 +48,23 @@ test_that("make_binomial_name works", {
     c("[Ruminococcus] gnavus", NA))
 })
 
-test_that("format_lineage_vector works", {
+test_that("format_lineage_vector works for unclassified taxa", {
   expect_equal(
     format_lineage_vector(c("a", "b", "c", "d"), 2),
     "b - d")
-  expect_equal(format_lineage_vector(
-    c("a", "b", "c", "d", NA), 2),
+  expect_equal(
+    format_lineage_vector(c("a", "b", "c", "d", NA), 2),
     "b - unclassified d")
-  expect_equal(format_lineage_vector(
-    c("a", "b", "c", "d", NA, NA), 2),
+  expect_equal(
+    format_lineage_vector(c("a", "b", "c", "d", NA, NA), 2),
     "b - unclassified d")
+  expect_equal(
+    format_lineage_vector(c("a", "b", NA, NA), 2),
+    "b")
+  expect_equal(
+    format_lineage_vector(c("a", NA, NA), 2),
+    "a")
+  expect_equal(
+    format_lineage_vector(c(NA_character_, NA_character_), 2),
+    NA_character_)
 })

--- a/tests/testthat/test-taxa.R
+++ b/tests/testthat/test-taxa.R
@@ -38,7 +38,7 @@ test_that("remove_rank_prefix works for lineages", {
       "Bacteria; Firmicutes; Clostridia; Clostridiales"))
 })
 
-test_that("simplify_assignments works", {
+test_that("format_taxa works", {
   expect_equal(format_taxa(taxa[, 1:6]), assignments) # Kingdom-Genus
 })
 

--- a/tests/testthat/test-taxa.R
+++ b/tests/testthat/test-taxa.R
@@ -61,23 +61,17 @@ test_that("make_binomial_name works", {
 
 test_that("format_lineage_vector works for unclassified taxa", {
   expect_equal(
-    format_lineage_vector(c("a", "b", "c", "d"), guide_idx = 2),
-    "b - d")
+    format_lineage_vector(c("a", "b", "c", "d")), "b - d")
   expect_equal(
-    format_lineage_vector(c("a", "b", "c", "d", NA), guide_idx = 2),
-    "b - unclassified d")
+    format_lineage_vector(c("a", "b", "c", "d", NA)), "b - unclassified d")
   expect_equal(
-    format_lineage_vector(c("a", "b", "c", "d", NA, NA), guide_idx = 2),
-    "b - unclassified d")
+    format_lineage_vector(c("a", "b", "c", "d", NA, NA)), "b - unclassified d")
   expect_equal(
-    format_lineage_vector(c("a", "b", NA, NA), guide_idx = 2),
-    "unclassified b")
+    format_lineage_vector(c("a", "b", NA, NA)), "unclassified b")
   expect_equal(
-    format_lineage_vector(c("a", NA, NA), guide_idx = 2),
-    "unclassified a")
+    format_lineage_vector(c("a", NA, NA)), "unclassified a")
   expect_equal(
-    format_lineage_vector(c(NA_character_, NA_character_), guide_idx = 2),
-    NA_character_)
+    format_lineage_vector(c(NA_character_, NA_character_)), NA_character_)
 })
 
 test_that("format_lineage_vector works without guide taxon", {

--- a/tests/testthat/test-taxa.R
+++ b/tests/testthat/test-taxa.R
@@ -12,10 +12,7 @@ taxa <- tibble::tibble(
   Genus = c("g__Enterococcus", NA_character_, NA_character_),
   Species = c(NA_character_, NA_character_, NA_character_))
 
-assignments <- c(
-  "p__Firmicutes - g__Enterococcus",
-  "p__Actinobacteria - unclassified f__Bifidobacteriaceae",
-  "p__Firmicutes - unclassified o__Clostridiales")
+assignments <-
 
 test_that("split_lineage works", {
   expect_equal(split_lineage(lineages), taxa)
@@ -39,7 +36,21 @@ test_that("remove_rank_prefix works for lineages", {
 })
 
 test_that("format_taxa works", {
-  expect_equal(format_taxa(taxa[, 1:6]), assignments) # Kingdom-Genus
+  expect_equal(
+    format_taxa(taxa[, 1:6]), # Kingdom-Genus
+    c(
+      "p__Firmicutes - g__Enterococcus",
+      "p__Actinobacteria - unclassified f__Bifidobacteriaceae",
+      "p__Firmicutes - unclassified o__Clostridiales"))
+})
+
+test_that("format_taxa works with no guide taxon", {
+  expect_equal(
+    format_taxa(taxa[, 1:6], guide = NULL),
+    c(
+      "g__Enterococcus",
+      "unclassified f__Bifidobacteriaceae",
+      "unclassified o__Clostridiales"))
 })
 
 test_that("make_binomial_name works", {
@@ -50,21 +61,25 @@ test_that("make_binomial_name works", {
 
 test_that("format_lineage_vector works for unclassified taxa", {
   expect_equal(
-    format_lineage_vector(c("a", "b", "c", "d"), 2),
+    format_lineage_vector(c("a", "b", "c", "d"), guide_idx = 2),
     "b - d")
   expect_equal(
-    format_lineage_vector(c("a", "b", "c", "d", NA), 2),
+    format_lineage_vector(c("a", "b", "c", "d", NA), guide_idx = 2),
     "b - unclassified d")
   expect_equal(
-    format_lineage_vector(c("a", "b", "c", "d", NA, NA), 2),
+    format_lineage_vector(c("a", "b", "c", "d", NA, NA), guide_idx = 2),
     "b - unclassified d")
   expect_equal(
-    format_lineage_vector(c("a", "b", NA, NA), 2),
-    "b")
+    format_lineage_vector(c("a", "b", NA, NA), guide_idx = 2),
+    "unclassified b")
   expect_equal(
-    format_lineage_vector(c("a", NA, NA), 2),
-    "a")
+    format_lineage_vector(c("a", NA, NA), guide_idx = 2),
+    "unclassified a")
   expect_equal(
-    format_lineage_vector(c(NA_character_, NA_character_), 2),
+    format_lineage_vector(c(NA_character_, NA_character_), guide_idx = 2),
     NA_character_)
+})
+
+test_that("format_lineage_vector works without guide taxon", {
+  expect_equal(format_lineage_vector(c("a", "b"), guide_idx = NULL), "b")
 })

--- a/tests/testthat/test-taxa.R
+++ b/tests/testthat/test-taxa.R
@@ -53,6 +53,12 @@ test_that("format_taxa works with no guide taxon", {
       "unclassified o__Clostridiales"))
 })
 
+test_that("format_taxa works with no assignment", {
+  expect_equal(
+    format_taxa(tibble::tibble(Kingdom = NA_character_, Phylum = NA_character_)),
+    "no assignment")
+})
+
 test_that("make_binomial_name works", {
   expect_equal(
     make_binomial_name(c("[Ruminococcus]", "Bacteroides"), c("gnavus", NA)),
@@ -71,7 +77,7 @@ test_that("format_lineage_vector works for unclassified taxa", {
   expect_equal(
     format_lineage_vector(c("a", NA, NA)), "unclassified a")
   expect_equal(
-    format_lineage_vector(c(NA_character_, NA_character_)), NA_character_)
+    format_lineage_vector(c(NA_character_, NA_character_)), "no assignment")
 })
 
 test_that("format_lineage_vector works without guide taxon", {


### PR DESCRIPTION
Fixed a few bugs and made some of the behavior more sensible in format_taxa:

- We now return the correct result when there is more than one unclassified taxon
- A guide taxon is optional
- When there is no classification below the guide taxon, we now use the unclassified_prefix
- Added a new parameter, all_unclassified, which is used if all taxa are NA
